### PR TITLE
exporters now output the actual email id as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.andrewl</groupId>
     <artifactId>emailindexer</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/nl/andrewl/email_indexer/data/export/datasample/datatype/PdfExporter.java
+++ b/src/main/java/nl/andrewl/email_indexer/data/export/datasample/datatype/PdfExporter.java
@@ -101,6 +101,8 @@ public final class PdfExporter implements TypeExporter {
 
 	private void writeThreadInDocument(Document document, EmailEntry email, String index) throws DocumentException {
 		addText("Email " + index, document, HEADER_TEXT);
+		addText("Email id:", document, SUBHEADER_TEXT);
+		addText(String.valueOf(email.id()), document, REGULAR_TEXT);
 		addText("Subject:", document, SUBHEADER_TEXT);
 		addText(email.subject() + "\n\n", document, REGULAR_TEXT);
 		addText("Sent from:", document, SUBHEADER_TEXT);

--- a/src/main/java/nl/andrewl/email_indexer/data/export/datasample/datatype/TxtExporter.java
+++ b/src/main/java/nl/andrewl/email_indexer/data/export/datasample/datatype/TxtExporter.java
@@ -89,6 +89,7 @@ public final class TxtExporter implements TypeExporter {
 									   PrintWriter p, int indentLevel) {
 		String indent = "\t".repeat(indentLevel);
 		p.println(indent + "Message id: " + email.messageId());
+		p.println(indent + "Email id: " + email.id());
 		p.println(indent + "Subject: " + email.subject());
 		p.println(indent + "Sent from: " + email.sentFrom());
 		p.println(indent + "Date: " + email.date());


### PR DESCRIPTION
I'm sorry to make a PR this quickly again, I was literally implementing it when you merged the previous PR ':D
The id that's currently outputted is the one formatted as an email though (i think it's the ``.mbox`` id or something?), and I can't really use that to easily navigate through the search engine. 